### PR TITLE
主要增加多配置目录支持UTF-8编码,且内置spring内置方法，获取对应配置信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Spring-Boot-I18-Pro
 ### Spring-boot+thymeleaf+Bootstrap的国际化模板
 
-博客文章[在Spring-Boot上加强国际化功能](http://zzzzbw.cn/article/7)的源代码
+原 博客文章[在Spring-Boot上加强国际化功能](http://zzzzbw.cn/article/7)的源代码
+
+增加功能 不使用注解情况下，不使用控制器，在业务流程内部返回 对应的语言文子
+
+浏览地址
+````http
+http://localhost:9090/module?locale=zh_CN
+````
+模块案例.`controller.ModuleController`
+
 
 相关截图
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.RELEASE</version>
+		<version>2.1.4.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/src/main/java/com/zbw/i18n/compoment/MessageResourceExtension.java
+++ b/src/main/java/com/zbw/i18n/compoment/MessageResourceExtension.java
@@ -59,7 +59,14 @@ public class MessageResourceExtension extends ResourceBundleMessageSource {
         }
         //设置父MessageSource
         ResourceBundleMessageSource parent = new ResourceBundleMessageSource();
-        parent.setBasename(basename);
+        //是否是多个目录
+        if (basename.indexOf(",") > 0) {
+            parent.setBasenames(basename.split(","));
+        } else {
+            parent.setBasename(basename);
+        }
+        //设置文件编码
+        parent.setDefaultEncoding("UTF-8");
         this.setParentMessageSource(parent);
     }
 

--- a/src/main/java/com/zbw/i18n/controller/ModuleController.java
+++ b/src/main/java/com/zbw/i18n/controller/ModuleController.java
@@ -1,0 +1,31 @@
+package com.zbw.i18n.controller;
+
+import com.zbw.i18n.util.LocaleMessage;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+
+
+/**
+ * @author fox
+ */
+@RestController
+public class ModuleController {
+
+    @Resource
+    private LocaleMessage localeMessage;
+
+    @GetMapping("/module")
+    public String hello() {
+        System.out.println("1");
+        String msg3 = localeMessage.getMessage("module.title");
+        System.out.println("module.title:"+msg3);
+        msg3 = localeMessage.getMessage("title");
+        System.out.println("title:"+localeMessage.getMessage("title"));
+
+        System.out.println("title:"+msg3);
+        System.out.println(localeMessage.getLocale());
+        return msg3;
+    }
+}

--- a/src/main/java/com/zbw/i18n/util/LocaleMessage.java
+++ b/src/main/java/com/zbw/i18n/util/LocaleMessage.java
@@ -1,0 +1,56 @@
+package com.zbw.i18n.util;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+@Component
+public class LocaleMessage {
+
+    @Autowired
+    private MessageSource messageSource;
+
+    /**
+     * @param code：对应文本配置的key.
+     * @return 对应地区的语言消息字符串
+     */
+    public String getMessage(String code) {
+        return this.getMessage(code, new Object[]{});
+    }
+
+    public String getMessage(String code, String defaultMessage) {
+        return this.getMessage(code, null, defaultMessage);
+    }
+
+    public String getMessage(String code, String defaultMessage, Locale locale) {
+        return this.getMessage(code, null, defaultMessage, locale);
+    }
+
+    public String getMessage(String code, Locale locale) {
+        return this.getMessage(code, null, "", locale);
+    }
+
+    public String getMessage(String code, Object[] args) {
+        return this.getMessage(code, args, "");
+    }
+
+    public String getMessage(String code, Object[] args, Locale locale) {
+        return this.getMessage(code, args, "", locale);
+    }
+
+    public String getMessage(String code, Object[] args, String defaultMessage) {
+        Locale locale = LocaleContextHolder.getLocale();
+        return this.getMessage(code, args, defaultMessage, locale);
+    }
+
+    public String getMessage(String code, Object[] args, String defaultMessage, Locale locale) {
+        return messageSource.getMessage(code, args, defaultMessage, locale);
+    }
+
+    public Locale getLocale() {
+        return LocaleContextHolder.getLocale();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 #\u7AEF\u53E3\u53F7
 server.port=9090
-spring.messages.basename=i18n/messages
+spring.messages.basename=i18n/messages,i18n/module/module
+spring.messages.encoding=UTF-8
 #thymeleaf start
 spring.thymeleaf.mode=HTML
 spring.thymeleaf.encoding=UTF-8

--- a/src/main/resources/i18n/module/module_en_US.properties
+++ b/src/main/resources/i18n/module/module_en_US.properties
@@ -1,0 +1,2 @@
+module.title=module
+title=module2

--- a/src/main/resources/i18n/module/module_zh_CN.properties
+++ b/src/main/resources/i18n/module/module_zh_CN.properties
@@ -1,0 +1,2 @@
+module.title=模块
+title=模块2


### PR DESCRIPTION
升级spring-boot-starter-parent版本2.1.4.RELEASE 
增加多配置目录，增加配置文件编码
增加案例配置文件
不使用编码注解情况下，使用内置spring内置方法，获取对应配置信息(在不使用模板不使用注解情况下)
增加获取配置文本信息案例
增加多个语言目录，增加文件编码UTF-8